### PR TITLE
Fix macOS CI: stop ITK_USE_FILE polluting global include path

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -23,7 +23,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND  CMAKE_CXX_COMPILER_VERSION V
 else()
     find_package(ITK REQUIRED)
 endif()
-include(${ITK_USE_FILE})
 set(ITKIOTransformLibs
     ITKIOTransformBase
     ITKIOTransformHDF5


### PR DESCRIPTION
## Summary

`cmake/FindDependencies.cmake` was calling `include(${ITK_USE_FILE})`, which uses the legacy `UseITK.cmake` pattern that adds ITK's include directories with directory-scoped `include_directories()` (plain `-I`, not `-isystem`). Those entries leak into every downstream subdirectory — including `tests/`, where GoogleTest is brought in via FetchContent.

On `macos-latest` (Xcode 16.4), the stricter libc++ rejects the resulting search order with:

```
<cstdint> tried including <stdint.h> but didn't find libc++'s <stdint.h> header.
```

because an ITK-bundled header dir gets searched before the SDK's libc++ wrappers.

`core/CMakeLists.txt` already links the ITK modules it needs as imported targets (`ITKCommon`, `ITKTransform`, `ITKOptimizers`, `ITKIOTransform*`), each of which propagates its own `INTERFACE_INCLUDE_DIRECTORIES` per-target. Removing the global include therefore keeps every consumer building, while preventing the include-path pollution that breaks the macOS test job.

## Test plan
- [x] `test:ubuntu:24.04` still green
- [x] `test:ubuntu:22.04` still green
- [x] `test:macos` now builds and passes